### PR TITLE
Fix: update actions/upload-artifact to v4 in CI workflow to resolve failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           pytest --maxfail=1 --disable-warnings -q --cov=financelake --cov-report=xml
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to use the latest stable version (v4) of actions/upload-artifact instead of the outdated v3. 

> The previous version was causing CI failures.